### PR TITLE
ci: disable all cron schedules to stop burning Actions minutes

### DIFF
--- a/.github/workflows/auto-fix-budget.yml
+++ b/.github/workflows/auto-fix-budget.yml
@@ -1,9 +1,10 @@
 name: Auto-Fix Budget Monitoring
 
 on:
-  schedule:
-    # Run every hour to track budget in near real-time
-    - cron: '0 * * * *'
+  # schedule disabled — burns Actions minutes
+  # schedule:
+  #   # Run every hour to track budget in near real-time
+  #   - cron: '0 * * * *'
   workflow_dispatch: # Allow manual trigger
     inputs:
       budget_threshold:

--- a/.github/workflows/auto-fix-monitor.yml
+++ b/.github/workflows/auto-fix-monitor.yml
@@ -5,9 +5,10 @@ name: Auto-Fix Health Monitor
 # Alerts via GitHub issues when problems are detected
 
 on:
-  schedule:
-    # Run every 6 hours
-    - cron: '0 */6 * * *'
+  # schedule disabled — burns Actions minutes
+  # schedule:
+  #   # Run every 6 hours
+  #   - cron: '0 */6 * * *'
   workflow_dispatch: # Allow manual trigger
     inputs:
       check_hours:

--- a/.github/workflows/auto-fix-report.yml
+++ b/.github/workflows/auto-fix-report.yml
@@ -1,9 +1,10 @@
 name: Auto-Fix Performance Report
 
 on:
-  schedule:
-    # Run weekly on Monday at 9am UTC
-    - cron: '0 9 * * 1'
+  # schedule disabled — burns Actions minutes
+  # schedule:
+  #   # Run weekly on Monday at 9am UTC
+  #   - cron: '0 9 * * 1'
   workflow_dispatch:
     inputs:
       week_offset:

--- a/.github/workflows/drift-detection.yml
+++ b/.github/workflows/drift-detection.yml
@@ -1,9 +1,10 @@
 name: Drift Detection
 
 on:
-  schedule:
-    # Run weekly on Sunday at midnight UTC
-    - cron: '0 0 * * 0'
+  # schedule disabled — burns Actions minutes
+  # schedule:
+  #   # Run weekly on Sunday at midnight UTC
+  #   - cron: '0 0 * * 0'
   workflow_dispatch: # Allow manual trigger
 
 env:


### PR DESCRIPTION
## Summary
- Comment out `schedule:` / `cron:` triggers in all 4 workflow files that had them
- Each workflow retains `workflow_dispatch` so they can still be triggered manually
- Affected workflows:
  - `auto-fix-budget.yml` (was hourly `0 * * * *`)
  - `auto-fix-monitor.yml` (was every 6h `0 */6 * * *`)
  - `auto-fix-report.yml` (was weekly Monday 9am `0 9 * * 1`)
  - `drift-detection.yml` (was weekly Sunday midnight `0 0 * * 0`)

## Test plan
- [ ] Verify CI passes (YAML remains valid with `workflow_dispatch` as the only trigger)
- [ ] Confirm no scheduled runs appear after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled scheduled automation for background workflows; these operations now require manual triggering only. Existing manual trigger capabilities remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->